### PR TITLE
Update README: document TLS options and .NET 8.0 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Ping a SQL Server. For example to test connectivity through a firewall, testing a failover cluster or testing permissions.
 
-This is a .NET console app and should run fine on [all supported operating systems](https://github.com/dotnet/core/blob/main/release-notes/7.0/supported-os.md): Windows, Linux and macOS.
+This is a .NET console app and should run fine on [all supported operating systems](https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md): Windows, Linux and macOS.
 
 ## USAGE:
     SQLPing <Server> [OPTIONS]
@@ -22,6 +22,10 @@ This is a .NET console app and should run fine on [all supported operating syste
     -a, --failoverpartner               Use a custom failover partner
     -n, --nonstop                       Set this to true to continously ping the server. Default is ping once
     -w, --wait <SECONDS>     10         How long to wait, in seconds, between non-stop pings
+    --encrypt <VALUE>        true       Encryption mode: true|false|strict
+    -T, --trust-server-certificate      Trust server certificate without validation (DEV ONLY)
+    -H, --hostname-in-certificate       Override hostname for TLS certificate validation
+    --no-tnir                           Disable TransparentNetworkIPResolution
 
 ## SECURITY NOTES:
 
@@ -58,6 +62,47 @@ SQLPing myserver -u myusername -p mypassword
 - Always prefer environment variables or interactive prompts for production use
 - Connection strings in output have passwords redacted automatically
 
+## TLS/ENCRYPTION OPTIONS:
+
+### Connection Encryption
+
+By default, SQL Server connections use encryption. You can control this behavior with the following options:
+
+**--encrypt <true|false|strict>**
+- `true` (default): Encrypted connection with certificate validation
+- `false`: No encryption (not recommended for production)
+- `strict`: Strictest encryption mode (requires SQL Server 2022+)
+
+**-T, --trust-server-certificate**
+- For development/testing environments only
+- Bypasses certificate validation but maintains encryption
+- WARNING: Vulnerable to man-in-the-middle attacks in production
+
+**-H, --hostname-in-certificate <name>**
+- Override the expected hostname in the server's TLS certificate
+- Useful when connecting via IP address but certificate contains a specific hostname
+- Must match the Subject Alternative Name (SAN) or CN in the server's certificate
+
+**--no-tnir**
+- Disables TransparentNetworkIPResolution
+- Prevents automatic hostname-to-IP substitution that can break TLS name matching
+- Recommended when using `--hostname-in-certificate`
+
+### Examples
+
+```bash
+# Connect with strict encryption (SQL Server 2022+)
+SQLPing myserver -u myuser --encrypt strict
+
+# Development: connect via IP with self-signed certificate
+SQLPing 10.0.0.5 -u myuser -T --hostname-in-certificate sqlserver.local
+
+# Production: connect via IP with valid certificate, specify expected hostname
+SQLPing 10.0.0.5 -u myuser -H sqlserver.company.com --no-tnir
+
+# Disable encryption (not recommended)
+SQLPing myserver -u myuser --encrypt false
+```
 
 # Todo
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a .NET console app and should run fine on [all supported operating syste
     -c, --command                       SQL Command (default will return database information)
     -f, --failover                      This is a failover cluster / availability group, use MultiSubnetFailover=true
     -a, --failoverpartner               Use a custom failover partner
-    -n, --nonstop                       Set this to true to continously ping the server. Default is ping once
+    -n, --nonstop                       Set this to true to continuously ping the server. Default is ping once
     -w, --wait <SECONDS>     10         How long to wait, in seconds, between non-stop pings
     --encrypt <VALUE>        true       Encryption mode: true|false|strict
     -T, --trust-server-certificate      Trust server certificate without validation (DEV ONLY)


### PR DESCRIPTION
- Update OS support link from .NET 7.0 to 8.0
- Add four new TLS/encryption command-line options to OPTIONS section:
  - --encrypt (true|false|strict)
  - -T, --trust-server-certificate
  - -H, --hostname-in-certificate
  - --no-tnir
- Add comprehensive TLS/ENCRYPTION OPTIONS section with:
  - Detailed explanation of each encryption option
  - Security warnings for development-only features
  - Practical examples for different scenarios

These options were added in recent commits to provide fine-grained control over SQL Server connection encryption and certificate validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)